### PR TITLE
Fix errors with Ruby 1.9

### DIFF
--- a/Source/Ruby/lib/aquaticprime.rb
+++ b/Source/Ruby/lib/aquaticprime.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# encoding: utf-8
 
 # AquaticPrime is a cryptographically secure licensing method for shareware
 # applications. The Ruby implementation currently only generates licenses, and


### PR DESCRIPTION
This is required by Ruby 1.9, in order to fix following error:

lib/aquaticprime.rb:101: invalid multibyte char (US-ASCII)
lib/aquaticprime.rb:101: invalid multibyte char (US-ASCII)
lib/aquaticprime.rb:101: syntax error, unexpected $end, expecting '}'
    'Name' => 'Üsér Diacriticà',
                 ^
