### PR TITLE
Fixed: Non-ASCII chars caused the script to fail

### DIFF
--- a/Source/PHP/AquaticPrime.php
+++ b/Source/PHP/AquaticPrime.php
@@ -120,8 +120,16 @@ function getSignature($dict, $key, $privKey)
     
     // Escape apostrophes by un-quoting, adding apos, then re-quoting
     // so this turns ' into '\'' ... we have to double-slash for this php.
+
+    // Switch to UTF8 before otherwise escapeshellarg will strip out non-ASCII characters
+    $oldlocale =  setlocale(LC_CTYPE, 0);
+    setlocale(LC_CTYPE, "en_US.UTF-8");
+    
     $fixedApostrophes = escapeshellarg($total);
 
+    // restore localte
+    setlocale(LC_CTYPE, $oldlocale);
+    
     // This part is the most expensive below
     // We try to do it with native code first
     $aquatic_root = preg_replace('!((/[A-Za-z._-]+)+)/AquaticPrime\.php!', '$1', __FILE__);


### PR DESCRIPTION
escapeshellarg strips out non-ascii characters if the UTF8 is not explicitly set. This fix temporarily switches to UTF8 before calling escapeshellarg. I saw this bug when running the script under Apache - it didn't reproduce on the command line.
