### PR TITLE
Header file modification for CPP file usage

### DIFF
--- a/Source/CoreFoundation/AquaticPrime.h
+++ b/Source/CoreFoundation/AquaticPrime.h
@@ -26,6 +26,9 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 // Set the key - must be called first
 Boolean APSetKey(CFStringRef key);
 
@@ -39,3 +42,6 @@ CFStringRef APCopyHash(void);
 void APBlacklistAdd(CFStringRef blacklistEntry);
 void APSetBlacklist(CFArrayRef hashArray);
 
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Modified the header file so that linker errors are avoided when AquaticPrime.c/.h are used in a C++ based project.